### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ cm-super (0.3.4-16) UNRELEASED; urgency=medium
   * Use set -e rather than passing -e on the shebang-line.
   * Update standards version to 4.4.1, no changes needed.
   * Bump debhelper from old 9 to 12.
+  * Add missing build dependency on dh addon.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 28 Oct 2019 17:26:53 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ cm-super (0.3.4-16) UNRELEASED; urgency=medium
   * Bump debhelper from old 9 to 12.
   * Add missing build dependency on dh addon.
   * Refer to specific version of license GPL-2+.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 28 Oct 2019 17:26:53 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ cm-super (0.3.4-16) UNRELEASED; urgency=medium
   * Update standards version to 4.4.1, no changes needed.
   * Bump debhelper from old 9 to 12.
   * Add missing build dependency on dh addon.
+  * Refer to specific version of license GPL-2+.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 28 Oct 2019 17:26:53 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends-Indep: tex-common (>= 4.01), pfb2t1c2pfb
 Maintainer: Debian TeX maintainers <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>,
            Hilmar Preusse <hille42@web.de>
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Vcs-Git: https://github.com/debian-tex/cm-super.git
 Vcs-Browser: https://github.com/debian-tex/cm-super
 Homepage: https://ctan.org/tex-archive/fonts/ps-type1/cm-super

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: cm-super
 Section: fonts
 Priority: optional
-Build-Depends: debhelper-compat (= 12)
+Build-Depends: debhelper-compat (= 12), tex-common
 Build-Depends-Indep: tex-common (>= 4.01), pfb2t1c2pfb
 Maintainer: Debian TeX maintainers <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>,

--- a/debian/copyright
+++ b/debian/copyright
@@ -23,7 +23,7 @@ License: GPL-2+
  GNU General Public License for more details.
  .
  You should have received a copy of the GNU General Public License with
- the Debian GNU/Linux distribution in file /usr/share/common-licenses/GPL;
+ the Debian GNU/Linux distribution in file /usr/share/common-licenses/GPL-2;
  if not, write to the Free Software Foundation, Inc., 51 Franklin St, 
  Fifth Floor, Boston, MA  02110-1301 USA
  .


### PR DESCRIPTION
Fix some issues reported by lintian
* Add missing build dependency on dh addon. ([missing-build-dependency-for-dh_command](https://lintian.debian.org/tags/missing-build-dependency-for-dh_command.html))
* Refer to specific version of license GPL-2+. ([copyright-refers-to-symlink-license](https://lintian.debian.org/tags/copyright-refers-to-symlink-license.html), [copyright-refers-to-versionless-license-file](https://lintian.debian.org/tags/copyright-refers-to-versionless-license-file.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/cm-super/97390e95-038c-4230-b643-3e1e6ce0ef85.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/97390e95-038c-4230-b643-3e1e6ce0ef85/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/97390e95-038c-4230-b643-3e1e6ce0ef85/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/97390e95-038c-4230-b643-3e1e6ce0ef85/diffoscope)).
