### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -10,6 +10,12 @@ cm-super (0.3.4-16) UNRELEASED; urgency=medium
   [ Hilmar Preusse ]
   * Hand over some files from clean target to d/clean.
 
+  [ Debian Janitor ]
+  * Remove constraints unnecessary since stretch:
+    + Build-Depends-Indep: Drop versioned constraint on tex-common.
+    + cm-super-minimal: Drop versioned constraint on cm-super in Replaces.
+    + Remove 3 maintscript entries from 3 files.
+
  -- Hilmar Preusse <hille42@web.de>  Fri, 09 Apr 2021 23:29:02 +0200
 
 cm-super (0.3.4-15) unstable; urgency=medium

--- a/debian/cm-super-minimal.maintscript
+++ b/debian/cm-super-minimal.maintscript
@@ -1,1 +1,0 @@
-rm_conffile /etc/texmf/updmap.d/50cm-super-minimal.cfg 0.3.4-4

--- a/debian/cm-super-x11.maintscript
+++ b/debian/cm-super-x11.maintscript
@@ -1,1 +1,0 @@
-rm_conffile /etc/defoma/hints/cm-super-x11.hints 0.3.4-3

--- a/debian/cm-super.maintscript
+++ b/debian/cm-super.maintscript
@@ -1,1 +1,0 @@
-rm_conffile /etc/texmf/updmap.d/50cm-super.cfg 0.3.4-4

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: cm-super
 Section: fonts
 Priority: optional
 Build-Depends: debhelper-compat (= 12), tex-common
-Build-Depends-Indep: tex-common (>= 4.01), pfb2t1c2pfb
+Build-Depends-Indep: tex-common, pfb2t1c2pfb
 Maintainer: Debian TeX maintainers <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>,
            Hilmar Preusse <hille42@web.de>
@@ -14,7 +14,6 @@ Homepage: https://ctan.org/tex-archive/fonts/ps-type1/cm-super
 Package: cm-super-minimal
 Architecture: all
 Depends: ${misc:Depends}, texlive-latex-recommended
-Replaces: cm-super (<< 0.3.3-6)
 Description: TeX font package (minimal version) with CM/EC in Type1 in T1, T2*, TS1, X2 enc
  This package ships the 10pt version of the various fonts. For the full
  set please install cm-super.


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/cm-super/bab61412-85f1-46e8-ba38-fb90d7350a92.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in first set of .debs but not in second
    -rwxr-xr-x  root/root   DEBIAN/prerm

No differences were encountered between the control files of package \*\*cm-super\*\*
### Control files of package cm-super-minimal: lines which differ (wdiff format)
* [-Replaces: cm-super (<< 0.3.3-6)-]

No differences were encountered between the control files of package \*\*cm-super-x11\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/bab61412-85f1-46e8-ba38-fb90d7350a92/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/bab61412-85f1-46e8-ba38-fb90d7350a92/diffoscope)).
