### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -16,6 +16,7 @@ cm-super (0.3.4-16) UNRELEASED; urgency=medium
     + cm-super-minimal: Drop versioned constraint on cm-super in Replaces.
     + Remove 3 maintscript entries from 3 files.
   * Bump debhelper from old 12 to 13.
+  * Update standards version to 4.5.1, no changes needed.
 
  -- Hilmar Preusse <hille42@web.de>  Fri, 09 Apr 2021 23:29:02 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -17,6 +17,7 @@ cm-super (0.3.4-16) UNRELEASED; urgency=medium
     + Remove 3 maintscript entries from 3 files.
   * Bump debhelper from old 12 to 13.
   * Update standards version to 4.5.1, no changes needed.
+  * Remove empty maintainer scripts: None (postinst)
 
  -- Hilmar Preusse <hille42@web.de>  Fri, 09 Apr 2021 23:29:02 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -15,6 +15,7 @@ cm-super (0.3.4-16) UNRELEASED; urgency=medium
     + Build-Depends-Indep: Drop versioned constraint on tex-common.
     + cm-super-minimal: Drop versioned constraint on cm-super in Replaces.
     + Remove 3 maintscript entries from 3 files.
+  * Bump debhelper from old 12 to 13.
 
  -- Hilmar Preusse <hille42@web.de>  Fri, 09 Apr 2021 23:29:02 +0200
 

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: cm-super
 Section: fonts
 Priority: optional
-Build-Depends: debhelper-compat (= 12), tex-common
+Build-Depends: debhelper-compat (= 13), tex-common
 Build-Depends-Indep: tex-common, pfb2t1c2pfb
 Maintainer: Debian TeX maintainers <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>,

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends-Indep: tex-common, pfb2t1c2pfb
 Maintainer: Debian TeX maintainers <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>,
            Hilmar Preusse <hille42@web.de>
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 Vcs-Git: https://github.com/debian-tex/cm-super.git
 Vcs-Browser: https://github.com/debian-tex/cm-super
 Homepage: https://ctan.org/tex-archive/fonts/ps-type1/cm-super

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,8 +1,0 @@
-#!/bin/sh
-# postinst for cm-super-minimal
-
-#DEBHELPER#
-
-set -e
-
-exit 0


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Update standards version to 4.5.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

* Remove empty maintainer scripts: None (postinst) ([maintainer-script-empty](https://lintian.debian.org/tags/maintainer-script-empty))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/cm-super/b7d9d1f3-a8bb-4eb4-bcc3-48450a1a9535.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/b7d9d1f3-a8bb-4eb4-bcc3-48450a1a9535/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/b7d9d1f3-a8bb-4eb4-bcc3-48450a1a9535/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/b7d9d1f3-a8bb-4eb4-bcc3-48450a1a9535/diffoscope)).
